### PR TITLE
Fix: remove cursor visibility API calls for GNOME 49 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,14 @@ gnome-extensions install soft-brightness-plus@joelkitching.com.v42.shell-extensi
 - To build the extension zip files, run: `ninja -C build extension.zip`, the extension will be found under `build/extension.zip`.
 
 ## Changelog
+### Version 44
 
+#### sept 29, 2025
+
+- In Version 44, Removed usage of Clutter.CursorTracker.set_pointer_visible(), which no longer exists in GNOME Shell 45+ (especially under Wayland).
+  The extension previously attempted to hide the system cursor to enable "mouse cloning", but since the API was removed upstream, this functionality caused runtime errors (TypeError: set_pointer_visible is not a function).
+  As a result, cursor hiding/cloning is now disabled. Brightness control via overlay continues to work as expected on GNOME 49.
+  
 ### Version 43
 #### April 30, 2025
 

--- a/meson.build
+++ b/meson.build
@@ -36,7 +36,7 @@
 
 # Boilerplate
 project('soft-brightness-plus',
-	version: '43',
+	version: '44',
 	meson_version: '>= 0.50.0',
 	license: 'GPL3' )
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -482,8 +482,8 @@ class CursorManager {
         }
 
         if (newCloned) {
-            this._logger.log_debug('CursorManager: enable mouse cloning');
-            this._enableCloningMouse();
+            this._logger.log_debug('CursorManager: enable mouse cloning (no cloning)');
+            //this._enableCloningMouse();
         } else {
             this._logger.log_debug('CursorManager: disable mouse cloning');
             this._disableCloningMouse();
@@ -609,37 +609,18 @@ class CursorManager {
         });
     }
 
+   
     _showSystemCursor() {
-        const seat = Clutter.get_default_backend().get_default_seat();
-
-        if (this._cursorUnfocusInhibited) {
-            seat.uninhibit_unfocus();
-            this._cursorUnfocusInhibited = false;
-        }
-
-        if (this._cursorVisibilityChangedId) {
-            this._cursorTracker.disconnect(this._cursorVisibilityChangedId);
-            delete this._cursorVisibilityChangedId;
-
-            this._cursorTracker.set_pointer_visible(true);
-        }
+        // GNOME 49: no podemos restaurar visibilidad porque API fue eliminada
+        log("soft-brightness-plus: _showSystemCursor() skipped (API removed)");
+        this._cursorUnfocusInhibited = false;
+        this._cursorVisibilityChangedId = 0;
     }
-
     _hideSystemCursor() {
-        const seat = Clutter.get_default_backend().get_default_seat();
-
-        if (!this._cursorUnfocusInhibited) {
-            seat.inhibit_unfocus();
-            this._cursorUnfocusInhibited = true;
-        }
-
-        if (!this._cursorVisibilityChangedId) {
-            this._cursorTracker.set_pointer_visible(false);
-            this._cursorVisibilityChangedId = this._cursorTracker.connect('visibility-changed', () => {
-                if (this._cursorTracker.get_pointer_visible())
-                    this._cursorTracker.set_pointer_visible(false);
-            });
-        }
+        // GNOME 49: API set_pointer_visible() y seat.inhibit_unfocus() ya no existen
+        log("soft-brightness-plus: _hideSystemCursor() skipped (API removed)");
+        this._cursorUnfocusInhibited = true;
+        this._cursorVisibilityChangedId = 0;
     }
 }
 

--- a/src/metadata.json.in
+++ b/src/metadata.json.in
@@ -11,7 +11,8 @@
     "45",
     "46",
     "47",
-    "48"
+    "48",
+    "49"
   ],
   "url": "https://github.com/jkitching/soft-brightness-plus",
   "uuid": "@uuid@",


### PR DESCRIPTION
Fix for GNOME 49 compatibility

This PR removes usage of Clutter.CursorTracker.set_pointer_visible(), which was removed in GNOME 45+.
Without this change, the extension throws runtime errors on GNOME 49 under Wayland.

Cursor hiding/cloning functionality is disabled, but brightness control remains fully functional.