### PR TITLE
add support for GNOME 50

### DIFF
--- a/src/metadata.json.in
+++ b/src/metadata.json.in
@@ -12,7 +12,8 @@
     "46",
     "47",
     "48",
-    "49"
+    "49",
+    "50"
   ],
   "url": "https://github.com/jkitching/soft-brightness-plus",
   "uuid": "@uuid@",


### PR DESCRIPTION
Added support for GNOME 50. Updated metadata.json and verified compatibility on Fedora 44 (GNOME 50). The extension is working correctly with the new shell version.