### PR TITLE
Fix cursor visibility API compatibility with newer GNOME Shell versions

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -597,6 +597,7 @@ class CursorManager {
         // Set/destroyed by _hideSystemCursor/_showSystemCursor
         this._cursorUnfocusInhibited = false;
         this._cursorHidden = false;
+        this._cursorVisibilityFallback = false;
     }
 
     setChangeHook(fn) {
@@ -773,7 +774,12 @@ class CursorManager {
 
         if (this._cursorHidden) {
             this._cursorHidden = false;
-            this._cursorTracker.uninhibit_cursor_visibility();
+            if (this._cursorTracker.uninhibit_cursor_visibility !== undefined) {
+                this._cursorTracker.uninhibit_cursor_visibility();
+            } else if (this._cursorVisibilityFallback) {
+                global.stage.set_cursor_type(Clutter.CursorType.DEFAULT);
+                this._cursorVisibilityFallback = false;
+            }
         }
     }
 
@@ -787,7 +793,12 @@ class CursorManager {
 
         if (!this._cursorHidden) {
             this._cursorHidden = true;
-            this._cursorTracker.inhibit_cursor_visibility();
+            if (this._cursorTracker.inhibit_cursor_visibility !== undefined) {
+                this._cursorTracker.inhibit_cursor_visibility();
+            } else {
+                global.stage.set_cursor_type(Clutter.CursorType.NONE);
+                this._cursorVisibilityFallback = true;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #53

## Summary
Adds fallback cursor visibility handling for GNOME Shell versions where `Meta.CursorTracker.inhibit_cursor_visibility()` and `uninhibit_cursor_visibility()` methods are not available in the JavaScript bindings.

## Changes
- Added runtime check for cursor visibility methods availability
- Implements fallback using `global.stage.set_cursor_type()` when tracker methods unavailable
- Maintains full backward compatibility with versions that have the methods
- Preserves input focus inhibition via `ClutterSeat` unchanged

## Technical Details
The fix uses a dual-path approach:
1. **Primary path**: Uses `Meta.CursorTracker` methods when available (original behavior)
2. **Fallback path**: Uses `global.stage.set_cursor_type()` when methods not found
   - Hide: Sets cursor to `Clutter.CursorType.NONE`
   - Show: Sets cursor to `Clutter.CursorType.DEFAULT`

The implementation gracefully degrades without crashes on any GNOME Shell version.

## Testing
Please verify the extension:
- Works on GNOME Shell versions with the tracker methods
- Doesn't crash on GNOME Shell versions without the methods
- Cursor visibility controls function as expected