### PR TITLE
Redesign prefs: brightness + white compression as independent controls

### DIFF
--- a/schemas/org.gnome.shell.extensions.soft-brightness-plus.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.soft-brightness-plus.gschema.xml
@@ -32,12 +32,13 @@
     </key>
     <key name="shader-gamma" type="d">
       <range min="1.0" max="4.0"/>
-      <default>2.0</default>
-      <summary>Gamma exponent for the GLSL dimming curve.</summary>
-      <description>Controls the gamma curve applied when dimming.
-      1.0 gives a linear result (whites and darks dim equally). Values
-      above 1.0 preserve dark content better while compressing highlights
-      more aggressively — 2.0 is the recommended starting point.</description>
+      <default>1.0</default>
+      <summary>White compression strength.</summary>
+      <description>Reshapes the brightness curve so whites are less
+      harsh without uniformly darkening the screen. 1.0 = off (linear,
+      whites and darks scale equally). Higher values compress highlights
+      more aggressively while preserving dark content — 2.0 is a good
+      starting point for eye comfort.</description>
     </key>
     <key name="debug" type="b">
       <default>false</default>

--- a/src/extension.js
+++ b/src/extension.js
@@ -196,22 +196,33 @@ export default class SoftBrightnessExtension extends Extension {
     }
 
     _on_brightness_change() {
+        const useBacklight = this._settings.get_boolean('use-backlight');
+        const gammaK = this._settings.get_double('shader-gamma');
         let curBrightness = this._getBrightnessLevel();
         const minBrightness = this._settings.get_double('min-brightness');
 
-        this._logger.log_debug('_on_brightness_change: current-brightness=' + curBrightness + ', min-brightness=' + minBrightness);
-        if (curBrightness < minBrightness) {
+        this._logger.log_debug('_on_brightness_change: current-brightness=' + curBrightness +
+            ', min-brightness=' + minBrightness + ', use-backlight=' + useBacklight + ', gamma=' + gammaK);
+
+        // Enforce minimum brightness floor only in shader-controlled mode.
+        if (!useBacklight && curBrightness < minBrightness) {
             curBrightness = minBrightness;
             this._storeBrightnessLevel(minBrightness);
             return;
         }
-        if (curBrightness >= 1) {
+
+        // In backlight mode the hardware controls overall brightness; the shader
+        // gets brightness=1.0 so it only applies the gamma curve, not dimming.
+        const shaderBrightness = useBacklight ? 1.0 : curBrightness;
+        const shaderNeeded = gammaK > 1.0 || shaderBrightness < 1.0;
+
+        if (shaderNeeded) {
+            this._overlayManager.showOverlays(shaderBrightness);
+            // Cursor cloning only makes sense when the shader is actually dimming.
+            this._cursorManager.setActive(!useBacklight && this._overlayManager.initialized());
+        } else {
             this._overlayManager.hideOverlays();
             this._cursorManager.setActive(false);
-        } else {
-            this._overlayManager.showOverlays(curBrightness);
-            // Only activate cursor if overlays were successfully created
-            this._cursorManager.setActive(this._overlayManager.initialized());
         }
     }
 

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -112,7 +112,7 @@ const PreferencesPage = GObject.registerClass(class PreferencesPage extends Adw.
 
             this.shader_gamma_control = new Adw.SpinRow({
                 title: _('Strength:'),
-                subtitle: this._getDescription('shader-gamma'),
+                subtitle: _('1.0 = off. Higher values compress bright highlights more aggressively. 2.0 is a good starting point.'),
                 digits: 2,
                 adjustment: new Gtk.Adjustment({
                     lower: 1.0,

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -105,7 +105,6 @@ const PreferencesPage = GObject.registerClass(class PreferencesPage extends Adw.
             const wcEnabled = initialGamma > 1.0;
             this.white_compression_row = new Adw.ExpanderRow({
                 title: _('White compression'),
-                subtitle: _('Reshapes the brightness curve so whites are less harsh without darkening the whole screen.'),
                 show_enable_switch: true,
                 enable_expansion: wcEnabled,
                 expanded: wcEnabled,

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -108,7 +108,7 @@ const PreferencesPage = GObject.registerClass(class PreferencesPage extends Adw.
             this.min_brightness_control.add_suffix(mbBox);
             this.min_brightness_control.set_activatable_widget(mbScale);
             this._settings.bind('min-brightness', mbScale.get_adjustment(), 'value', Gio.SettingsBindFlags.DEFAULT);
-            const mbFmt = (v) => v < 0.005 ? _('Off') : v.toFixed(2);
+            const mbFmt = (v) => v < 0.005 ? _('None') : v.toFixed(2);
             this.mbLabel.set_label(mbFmt(mbScale.get_value()));
             mbScale.connect('value-changed', () => this.mbLabel.set_label(mbFmt(mbScale.get_value())));
             group.add(this.min_brightness_control);

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -115,6 +115,7 @@ const PreferencesPage = GObject.registerClass(class PreferencesPage extends Adw.
 
             this.white_compression_row = new Adw.ActionRow({
                 title: _('White compression'),
+                subtitle: _('Softens bright highlights without uniformly darkening the screen. Higher values are more aggressive.'),
             });
             const wcScale = new Gtk.Scale({
                 orientation: Gtk.Orientation.HORIZONTAL,

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -83,7 +83,6 @@ const PreferencesPage = GObject.registerClass(class PreferencesPage extends Adw.
                 title: _('Use hardware backlight'),
                 subtitle: _('When on, the brightness slider adjusts the hardware backlight. When off, the extension dims via the GPU shader.'),
             });
-            // Inverted binding: when switch is ON, use-backlight is true
             this._settings.bind('use-backlight', this.enabled_control, 'active', Gio.SettingsBindFlags.DEFAULT);
             group.add(this.enabled_control);
 
@@ -100,17 +99,18 @@ const PreferencesPage = GObject.registerClass(class PreferencesPage extends Adw.
             this._settings.bind('min-brightness', this.min_brightness_control, 'value', Gio.SettingsBindFlags.DEFAULT);
             group.add(this.min_brightness_control);
 
-            this.add(group);
-        }
-
-        {
-            const group = new Adw.PreferencesGroup({
+            // White compression as an expander: the enable-switch acts as the
+            // mode toggle, and the strength slider is only visible when active.
+            const initialGamma = this._settings.get_double('shader-gamma');
+            this.white_compression_row = new Adw.ExpanderRow({
                 title: _('White compression'),
-                description: _('Reshapes the brightness curve so whites are less harsh without darkening the whole screen. Applied on top of the brightness setting.'),
+                subtitle: _('Reshapes the brightness curve so whites are less harsh without darkening the whole screen.'),
+                show_enable_switch: true,
+                enable_expansion: initialGamma > 1.0,
             });
 
             this.shader_gamma_control = new Adw.SpinRow({
-                title: _('Strength (1.0 = off, 4.0 = maximum):'),
+                title: _('Strength:'),
                 subtitle: this._getDescription('shader-gamma'),
                 digits: 2,
                 adjustment: new Gtk.Adjustment({
@@ -120,7 +120,19 @@ const PreferencesPage = GObject.registerClass(class PreferencesPage extends Adw.
                 }),
             });
             this._settings.bind('shader-gamma', this.shader_gamma_control, 'value', Gio.SettingsBindFlags.DEFAULT);
-            group.add(this.shader_gamma_control);
+            this.white_compression_row.add_row(this.shader_gamma_control);
+
+            // When the toggle is switched off, reset gamma to 1.0 (disabled).
+            // When switched on, restore to a sensible default if still at 1.0.
+            this.white_compression_row.connect('notify::enable-expansion', (row) => {
+                if (!row.enable_expansion) {
+                    this._settings.set_double('shader-gamma', 1.0);
+                } else if (this._settings.get_double('shader-gamma') <= 1.0) {
+                    this._settings.set_double('shader-gamma', 2.0);
+                }
+            });
+
+            group.add(this.white_compression_row);
 
             this.add(group);
         }

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -74,24 +74,21 @@ const PreferencesPage = GObject.registerClass(class PreferencesPage extends Adw.
         }
 
         {
-            const group = new Adw.PreferencesGroup();
+            const group = new Adw.PreferencesGroup({
+                title: _('Brightness'),
+                description: _('Controls overall screen dimming. Use the hardware backlight when available, or let the extension control it independently.'),
+            });
 
             this.enabled_control = new Adw.SwitchRow({
-                title: _('Control overlay brightness independently'),
-                subtitle: _('Show a separate slider in the quick settings menu.'),
+                title: _('Use hardware backlight'),
+                subtitle: _('When on, the brightness slider adjusts the hardware backlight. When off, the extension dims via the GPU shader.'),
             });
-            // Inverted binding: when switch is ON, use-backlight is false
-            this._settings.bind('use-backlight', this.enabled_control, 'active', Gio.SettingsBindFlags.INVERT_BOOLEAN);
+            // Inverted binding: when switch is ON, use-backlight is true
+            this._settings.bind('use-backlight', this.enabled_control, 'active', Gio.SettingsBindFlags.DEFAULT);
             group.add(this.enabled_control);
 
-            this.add(group);
-        }
-
-        {
-            const group = new Adw.PreferencesGroup();
-
             this.min_brightness_control = new Adw.SpinRow({
-                title: _('Minimum brightness (0..1):'),
+                title: _('Minimum brightness:'),
                 subtitle: this._getDescription('min-brightness'),
                 digits: 2,
                 adjustment: new Gtk.Adjustment({
@@ -103,8 +100,17 @@ const PreferencesPage = GObject.registerClass(class PreferencesPage extends Adw.
             this._settings.bind('min-brightness', this.min_brightness_control, 'value', Gio.SettingsBindFlags.DEFAULT);
             group.add(this.min_brightness_control);
 
+            this.add(group);
+        }
+
+        {
+            const group = new Adw.PreferencesGroup({
+                title: _('White compression'),
+                description: _('Reshapes the brightness curve so whites are less harsh without darkening the whole screen. Applied on top of the brightness setting.'),
+            });
+
             this.shader_gamma_control = new Adw.SpinRow({
-                title: _('Gamma (1..4):'),
+                title: _('Strength (1.0 = off, 4.0 = maximum):'),
                 subtitle: this._getDescription('shader-gamma'),
                 digits: 2,
                 adjustment: new Gtk.Adjustment({
@@ -116,15 +122,23 @@ const PreferencesPage = GObject.registerClass(class PreferencesPage extends Adw.
             this._settings.bind('shader-gamma', this.shader_gamma_control, 'value', Gio.SettingsBindFlags.DEFAULT);
             group.add(this.shader_gamma_control);
 
+            this.add(group);
+        }
+
+        {
+            const group = new Adw.PreferencesGroup({
+                title: _('Advanced'),
+            });
+
             this.clone_mouse_control = new Adw.SwitchRow({
-                title: _('Mouse cursor brightness control:'),
+                title: _('Apply to mouse cursor:'),
                 subtitle: this._getDescription('clone-mouse'),
             });
             this._settings.bind('clone-mouse', this.clone_mouse_control, 'active', Gio.SettingsBindFlags.DEFAULT);
             group.add(this.clone_mouse_control);
 
             this.debug_control = new Adw.SwitchRow({
-                title: _('Debug:'),
+                title: _('Debug logging:'),
                 subtitle: this._getDescription('debug'),
             });
             this._settings.bind('debug', this.debug_control, 'active', Gio.SettingsBindFlags.DEFAULT);

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -102,11 +102,13 @@ const PreferencesPage = GObject.registerClass(class PreferencesPage extends Adw.
             // White compression as an expander: the enable-switch acts as the
             // mode toggle, and the strength slider is only visible when active.
             const initialGamma = this._settings.get_double('shader-gamma');
+            const wcEnabled = initialGamma > 1.0;
             this.white_compression_row = new Adw.ExpanderRow({
                 title: _('White compression'),
                 subtitle: _('Reshapes the brightness curve so whites are less harsh without darkening the whole screen.'),
                 show_enable_switch: true,
-                enable_expansion: initialGamma > 1.0,
+                enable_expansion: wcEnabled,
+                expanded: wcEnabled,
             });
 
             this.shader_gamma_control = new Adw.SpinRow({

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -86,53 +86,58 @@ const PreferencesPage = GObject.registerClass(class PreferencesPage extends Adw.
             this._settings.bind('use-backlight', this.enabled_control, 'active', Gio.SettingsBindFlags.DEFAULT);
             group.add(this.enabled_control);
 
-            this.min_brightness_control = new Adw.SpinRow({
-                title: _('Minimum brightness:'),
-                subtitle: this._getDescription('min-brightness'),
-                digits: 2,
+            this.min_brightness_control = new Adw.ActionRow({
+                title: _('Minimum brightness'),
+            });
+            const mbScale = new Gtk.Scale({
+                orientation: Gtk.Orientation.HORIZONTAL,
+                hexpand: true,
+                width_request: 160,
+                draw_value: false,
+                valign: Gtk.Align.CENTER,
                 adjustment: new Gtk.Adjustment({
                     lower: 0.0,
                     upper: 1.0,
                     step_increment: 0.01,
                 }),
             });
-            this._settings.bind('min-brightness', this.min_brightness_control, 'value', Gio.SettingsBindFlags.DEFAULT);
+            this.mbLabel = new Gtk.Label({ width_chars: 5, xalign: 1.0, valign: Gtk.Align.CENTER });
+            const mbBox = new Gtk.Box({ spacing: 8, valign: Gtk.Align.CENTER });
+            mbBox.append(mbScale);
+            mbBox.append(this.mbLabel);
+            this.min_brightness_control.add_suffix(mbBox);
+            this.min_brightness_control.set_activatable_widget(mbScale);
+            this._settings.bind('min-brightness', mbScale.get_adjustment(), 'value', Gio.SettingsBindFlags.DEFAULT);
+            const mbFmt = (v) => v < 0.005 ? _('Off') : v.toFixed(2);
+            this.mbLabel.set_label(mbFmt(mbScale.get_value()));
+            mbScale.connect('value-changed', () => this.mbLabel.set_label(mbFmt(mbScale.get_value())));
             group.add(this.min_brightness_control);
 
-            // White compression as an expander: the enable-switch acts as the
-            // mode toggle, and the strength slider is only visible when active.
-            const initialGamma = this._settings.get_double('shader-gamma');
-            const wcEnabled = initialGamma > 1.0;
-            this.white_compression_row = new Adw.ExpanderRow({
+            this.white_compression_row = new Adw.ActionRow({
                 title: _('White compression'),
-                show_enable_switch: true,
-                enable_expansion: wcEnabled,
-                expanded: wcEnabled,
             });
-
-            this.shader_gamma_control = new Adw.SpinRow({
-                title: _('Strength:'),
-                subtitle: _('1.0 = off. Higher values compress bright highlights more aggressively. 2.0 is a good starting point.'),
-                digits: 2,
+            const wcScale = new Gtk.Scale({
+                orientation: Gtk.Orientation.HORIZONTAL,
+                hexpand: true,
+                width_request: 160,
+                draw_value: false,
+                valign: Gtk.Align.CENTER,
                 adjustment: new Gtk.Adjustment({
                     lower: 1.0,
                     upper: 4.0,
                     step_increment: 0.1,
                 }),
             });
-            this._settings.bind('shader-gamma', this.shader_gamma_control, 'value', Gio.SettingsBindFlags.DEFAULT);
-            this.white_compression_row.add_row(this.shader_gamma_control);
-
-            // When the toggle is switched off, reset gamma to 1.0 (disabled).
-            // When switched on, restore to a sensible default if still at 1.0.
-            this.white_compression_row.connect('notify::enable-expansion', (row) => {
-                if (!row.enable_expansion) {
-                    this._settings.set_double('shader-gamma', 1.0);
-                } else if (this._settings.get_double('shader-gamma') <= 1.0) {
-                    this._settings.set_double('shader-gamma', 2.0);
-                }
-            });
-
+            this.wcLabel = new Gtk.Label({ width_chars: 4, xalign: 1.0, valign: Gtk.Align.CENTER });
+            const wcBox = new Gtk.Box({ spacing: 8, valign: Gtk.Align.CENTER });
+            wcBox.append(wcScale);
+            wcBox.append(this.wcLabel);
+            this.white_compression_row.add_suffix(wcBox);
+            this.white_compression_row.set_activatable_widget(wcScale);
+            this._settings.bind('shader-gamma', wcScale.get_adjustment(), 'value', Gio.SettingsBindFlags.DEFAULT);
+            const wcFmt = (v) => v < 1.001 ? _('Off') : v.toFixed(1);
+            this.wcLabel.set_label(wcFmt(wcScale.get_value()));
+            wcScale.connect('value-changed', () => this.wcLabel.set_label(wcFmt(wcScale.get_value())));
             group.add(this.white_compression_row);
 
             this.add(group);


### PR DESCRIPTION
## Summary

- Gamma (white compression) now **always runs** regardless of `use-backlight` mode
- In backlight mode: hardware controls brightness level; shader applies gamma-only (brightness=1.0 passed to GLSL)
- In shader mode: shader controls both brightness and gamma as before
- `shader-gamma` default changed 2.0 → 1.0 so new installs start with identity behaviour

## Prefs page restructured into three groups

**Brightness**
- Use hardware backlight (toggle)
- Minimum brightness (floor, applies in shader mode only)

**White compression**
- Strength 1.0–4.0 (1.0 = off / linear, 4.0 = maximum highlight compression)

**Advanced**
- Apply to mouse cursor
- Debug logging

## What this enables

Hardware backlight + gamma curve together — common use case where the user sets backlight to a comfortable level and uses the gamma curve to soften white content independently.

## Test plan

- [ ] Shader mode: brightness + gamma work as before
- [ ] Backlight mode: brightness keys move hardware backlight; gamma curve still applies on top
- [ ] gamma=1.0: shader disabled entirely (no-op)
- [ ] GNOME 48 X11 test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)