### PR TITLE
Add keyboard shortcuts for brightness control

### DIFF
--- a/schemas/org.gnome.shell.extensions.soft-brightness-plus.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.soft-brightness-plus.gschema.xml
@@ -65,6 +65,18 @@
       or there may be multiple cursors shown on the screen.
       </description>
     </key>
+    <key name="brightness-up" type="as">
+      <default>['&lt;Shift&gt;XF86MonBrightnessUp']</default>
+      <summary>Keyboard shortcut: increase brightness.</summary>
+      <description>Keyboard shortcut to increase the overlay brightness by one step (5%).
+      Set to an empty list to disable.</description>
+    </key>
+    <key name="brightness-down" type="as">
+      <default>['&lt;Shift&gt;XF86MonBrightnessDown']</default>
+      <summary>Keyboard shortcut: decrease brightness.</summary>
+      <description>Keyboard shortcut to decrease the overlay brightness by one step (5%).
+      Set to an empty list to disable.</description>
+    </key>
     <key name="debug" type="b">
       <default>false</default>
       <summary>Debugging.</summary>

--- a/src/extension.js
+++ b/src/extension.js
@@ -143,6 +143,7 @@ export default class SoftBrightnessExtension extends Extension {
         );
 
         this._enableSettingsMonitoring();
+        this._enableKeyboardShortcuts();
 
         this._logger.log_debug('Extension enabled');
     }
@@ -153,6 +154,8 @@ export default class SoftBrightnessExtension extends Extension {
         // metadata.json.  The extension will remain active while the lock screen
         // is shown.
         this._logger.log_debug('disable(), session mode = ' + Main.sessionMode.currentMode);
+
+        this._disableKeyboardShortcuts();
 
         if (this._workspaceSwitchId) {
             global.workspace_manager.disconnect(this._workspaceSwitchId);
@@ -182,6 +185,33 @@ export default class SoftBrightnessExtension extends Extension {
     _on_debug_change() {
         this._logger.set_debug(this._settings.get_boolean('debug'));
         this._logger.log('debug = ' + this._logger.get_debug());
+    }
+
+    _enableKeyboardShortcuts() {
+        const step = 0.05;
+        Main.wm.addKeybinding('brightness-up', this._settings,
+            Meta.KeyBindingFlags.NONE,
+            Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW,
+            () => this._adjustBrightness(+step));
+        Main.wm.addKeybinding('brightness-down', this._settings,
+            Meta.KeyBindingFlags.NONE,
+            Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW,
+            () => this._adjustBrightness(-step));
+    }
+
+    _disableKeyboardShortcuts() {
+        Main.wm.removeKeybinding('brightness-up');
+        Main.wm.removeKeybinding('brightness-down');
+    }
+
+    _adjustBrightness(delta) {
+        const minBrightness = this._settings.get_double('min-brightness');
+        const current = this._getBrightnessLevel();
+        // Round to nearest step to avoid floating-point drift
+        const stepped = Math.round((current + delta) / 0.05) * 0.05;
+        const clamped = Math.max(minBrightness, Math.min(1.0, stepped));
+        this._logger.log_debug(`_adjustBrightness(${delta}): ${current} -> ${clamped}`);
+        this._storeBrightnessLevel(clamped);
     }
 
     _onWorkspaceChanged() {

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -218,6 +218,18 @@ const PreferencesPage = GObject.registerClass(class PreferencesPage extends Adw.
         }
 
         {
+            const group = new Adw.PreferencesGroup({
+                title: _('Keyboard shortcuts'),
+                description: _('Default shortcuts use Shift + hardware brightness keys. Clear to disable; use gsettings to set a custom binding.'),
+            });
+
+            group.add(this._buildShortcutRow(_('Increase brightness'), 'brightness-up'));
+            group.add(this._buildShortcutRow(_('Decrease brightness'), 'brightness-down'));
+
+            this.add(group);
+        }
+
+        {
             const group = new Adw.PreferencesGroup();
 
             const copyright1 = new Gtk.Label({
@@ -248,6 +260,41 @@ const PreferencesPage = GObject.registerClass(class PreferencesPage extends Adw.
 
     _getDescription(name) {
         return _(this._settings.settings_schema.get_key(name).get_description());
+    }
+
+    _buildShortcutRow(title, settingKey) {
+        const row = new Adw.ActionRow({ title });
+
+        const shortcutLabel = new Gtk.ShortcutLabel({
+            disabled_text: _('Disabled'),
+            valign: Gtk.Align.CENTER,
+        });
+
+        const refresh = () => {
+            const vals = this._settings.get_strv(settingKey);
+            shortcutLabel.accelerator = vals.length ? vals[0] : '';
+        };
+        refresh();
+        this._settings.connect(`changed::${settingKey}`, refresh);
+
+        const clearButton = new Gtk.Button({
+            label: _('Clear'),
+            valign: Gtk.Align.CENTER,
+        });
+        clearButton.add_css_class('flat');
+        clearButton.connect('clicked', () => this._settings.set_strv(settingKey, []));
+
+        const resetButton = new Gtk.Button({
+            label: _('Reset'),
+            valign: Gtk.Align.CENTER,
+        });
+        resetButton.add_css_class('flat');
+        resetButton.connect('clicked', () => this._settings.reset(settingKey));
+
+        row.add_suffix(shortcutLabel);
+        row.add_suffix(clearButton);
+        row.add_suffix(resetButton);
+        return row;
     }
 
     _bindBuiltinMonitorControl() {


### PR DESCRIPTION
## Summary

- **Default bindings**: `Shift+XF86MonBrightnessUp` / `Shift+XF86MonBrightnessDown`
- Adjusts overlay brightness in 5% steps, clamped to `min-brightness`
- Works alongside system backlight keys without conflict — no grabbing of unmodified `XF86MonBrightness*`
- Shortcuts are configurable via GSettings; empty array disables them

## Implementation

- `extension.js`: `_enableKeyboardShortcuts()` registers via `Main.wm.addKeybinding()`, `_adjustBrightness(delta)` handles step logic with rounding to avoid float drift
- Schema: `brightness-up` / `brightness-down` of type `as` (array of accelerators)
- Prefs: new "Keyboard shortcuts" group with `Gtk.ShortcutLabel` to display current binding and Clear/Reset buttons. Custom bindings can be set via `gsettings set org.gnome.shell.extensions.soft-brightness-plus brightness-up "['<Super>F5']"`

## Test plan

- [ ] `Shift+XF86MonBrightnessUp` increases brightness by 5% each press
- [ ] `Shift+XF86MonBrightnessDown` decreases, clamped at min-brightness
- [ ] Unmodified `XF86MonBrightness*` still controls hardware backlight normally
- [ ] Clear button in prefs disables the shortcut
- [ ] Reset button restores default
- [ ] Custom binding via gsettings is picked up without restart

Closes #12, closes #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)