### PR TITLE
fix(e2e): fix container permissions and session type for gnome-shell

### DIFF
--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -17,7 +17,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN useradd -ms /bin/bash tester && \
     mkdir -p /tmp/runtime-tester && \
     chown tester:tester /tmp/runtime-tester && \
-    chmod 700 /tmp/runtime-tester
+    chmod 700 /tmp/runtime-tester && \
+    mkdir -p /tmp/.X11-unix && \
+    chmod 1777 /tmp/.X11-unix
 
 COPY run-test.sh /run-test.sh
 RUN chmod +x /run-test.sh

--- a/test/e2e/run-test.sh
+++ b/test/e2e/run-test.sh
@@ -45,10 +45,12 @@ gsettings set org.gnome.shell enabled-extensions "['${UUID}']"
 
 if [ "${MODE}" = "x11" ]; then
     DISPLAY=:99 \
+    XDG_SESSION_TYPE=x11 \
     LIBGL_ALWAYS_SOFTWARE=1 \
     MUTTER_DISABLE_ANIMATIONS=1 \
         gnome-shell >"${LOG}" 2>&1 &
 else
+    XDG_SESSION_TYPE=wayland \
     MUTTER_DEBUG_DUMMY_MODE_SPECS="1920x1080" \
     MUTTER_DISABLE_ANIMATIONS=1 \
         gnome-shell --headless >"${LOG}" 2>&1 &


### PR DESCRIPTION
## Problem

The E2E container tests were failing in two ways:

**Wayland:**
\`\`\`
libmutter-ERROR: Failed to start X Wayland: Directory "/tmp/.X11-unix" is not writable
\`\`\`
The container runs as non-root user \`tester\`, and \`/tmp/.X11-unix\` doesn't exist. Mutter needs this directory (sticky-bit world-writable) to create the XWayland socket, even in headless mode.

**X11:**
\`\`\`
Failed to configure: Unsupported session type
\`\`\`
\`XDG_SESSION_TYPE\` wasn't set, so gnome-shell/mutter couldn't determine what backend to use.

## Fix

- **Dockerfile**: Create \`/tmp/.X11-unix\` with \`chmod 1777\` while still root, before switching to \`tester\`. Matches the standard host layout X11 expects.
- **run-test.sh**: Set \`XDG_SESSION_TYPE=x11\` for X11 mode and \`XDG_SESSION_TYPE=wayland\` for headless Wayland mode.