### PR TITLE
fix(e2e): stub logind via GJS to fix gnome-shell crash in Docker

### DIFF
--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -22,6 +22,7 @@ RUN useradd -ms /bin/bash tester && \
     chmod 1777 /tmp/.X11-unix
 
 COPY run-test.sh /run-test.sh
+COPY fake-logind.js /fake-logind.js
 RUN chmod +x /run-test.sh
 
 USER tester

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -17,7 +17,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN useradd -ms /bin/bash tester && \
     mkdir -p /tmp/runtime-tester && \
     chown tester:tester /tmp/runtime-tester && \
-    chmod 700 /tmp/runtime-tester
+    chmod 700 /tmp/runtime-tester && \
+    mkdir -p /tmp/.X11-unix && \
+    chmod 1777 /tmp/.X11-unix
 
 COPY run-test.sh /run-test.sh
 RUN chmod +x /run-test.sh

--- a/test/e2e/fake-logind.js
+++ b/test/e2e/fake-logind.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env gjs
+// Registers a minimal org.freedesktop.login1 stub on the system D-Bus.
+// Needed in Docker containers where no logind daemon is running.
+// gnome-shell connects to logind during background init; without this
+// it throws an uncaught exception that triggers a C-level heap corruption.
+
+const { GLib, Gio } = imports.gi;
+
+const XML = `
+<node>
+  <interface name="org.freedesktop.login1.Manager">
+    <method name="GetSession">
+      <arg type="s" direction="in" name="session_id"/>
+      <arg type="o" direction="out" name="object_path"/>
+    </method>
+    <method name="GetSessionByPID">
+      <arg type="u" direction="in" name="pid"/>
+      <arg type="o" direction="out" name="object_path"/>
+    </method>
+    <signal name="SessionNew">
+      <arg type="s" name="session_id"/>
+      <arg type="o" name="object_path"/>
+    </signal>
+    <signal name="SessionRemoved">
+      <arg type="s" name="session_id"/>
+      <arg type="o" name="object_path"/>
+    </signal>
+  </interface>
+</node>`;
+
+const SESSION_PATH = '/org/freedesktop/login1/session/c1';
+const loop = new GLib.MainLoop(null, false);
+
+let registrationId = 0;
+
+function onBusAcquired(conn) {
+    const iface = Gio.DBusNodeInfo.new_for_xml(XML).interfaces[0];
+    registrationId = conn.register_object(
+        '/org/freedesktop/login1',
+        iface,
+        (_conn, _sender, _path, _iface, _method, _params, invoc) => {
+            invoc.return_value(new GLib.Variant('(o)', [SESSION_PATH]));
+        },
+        null,
+        null
+    );
+}
+
+Gio.bus_own_name(
+    Gio.BusType.SYSTEM,
+    'org.freedesktop.login1',
+    Gio.BusNameOwnerFlags.NONE,
+    onBusAcquired,
+    null,
+    null
+);
+
+loop.run();

--- a/test/e2e/run-test.sh
+++ b/test/e2e/run-test.sh
@@ -45,10 +45,12 @@ gsettings set org.gnome.shell enabled-extensions "['${UUID}']"
 
 if [ "${MODE}" = "x11" ]; then
     DISPLAY=:99 \
+    XDG_SESSION_TYPE=x11 \
     LIBGL_ALWAYS_SOFTWARE=1 \
     MUTTER_DISABLE_ANIMATIONS=1 \
         gnome-shell >"${LOG}" 2>&1 &
 else
+    XDG_SESSION_TYPE=wayland \
     MUTTER_DEBUG_DUMMY_MODE_SPECS="1920x1080" \
     MUTTER_DISABLE_ANIMATIONS=1 \
         gnome-shell --headless >"${LOG}" 2>&1 &

--- a/test/e2e/run-test.sh
+++ b/test/e2e/run-test.sh
@@ -43,6 +43,19 @@ MODE="$1"; UUID="$2"; LOG="$3"; SETTLE="$4"
 # Enable the extension before gnome-shell reads settings
 gsettings set org.gnome.shell enabled-extensions "['${UUID}']"
 
+# Start a fake system D-Bus and register a logind stub on it.
+# gnome-shell connects to org.freedesktop.login1 on the system bus during
+# background init. Without this, it throws an uncaught exception that
+# causes a C-level heap abort in the GNOME Shell 46 error path.
+FAKE_SYSTEM_BUS=/tmp/fake-system-dbus.sock
+dbus-daemon --session \
+    --address="unix:path=${FAKE_SYSTEM_BUS}" \
+    --print-pid --fork >/dev/null
+export DBUS_SYSTEM_BUS_ADDRESS="unix:path=${FAKE_SYSTEM_BUS}"
+gjs /fake-logind.js &
+LOGIND_PID=$!
+sleep 1
+
 if [ "${MODE}" = "x11" ]; then
     DISPLAY=:99 \
     XDG_SESSION_TYPE=x11 \
@@ -88,5 +101,6 @@ fi
 
 kill "${GS_PID}" 2>/dev/null || true
 wait "${GS_PID}" 2>/dev/null || true
+kill "${LOGIND_PID}" 2>/dev/null || true
 echo "  PASS: ${MODE} test complete"
 INNER


### PR DESCRIPTION
## Problem

The E2E tests crash because gnome-shell 46 connects to `org.freedesktop.login1` on the **system D-Bus** during background initialisation (`loginManager.js:96`). In Docker containers without systemd/elogind running, this throws an uncaught JS exception that triggers a C-level heap abort:

```
(gnome-shell:26): Gjs-CRITICAL: JS ERROR: Gio.IOErrorEnum: Could not connect: No such file or directory
corrupted size vs. prev_size in fastbins
Aborted (core dumped)
```

## Fix (Option A — GJS stub)

- Add `test/e2e/fake-logind.js`: a minimal GJS script that registers `org.freedesktop.login1` on the system bus, responding to `GetSession`/`GetSessionByPID`.
- In `run-test.sh`, start a session-mode `dbus-daemon` on a custom socket, set `DBUS_SYSTEM_BUS_ADDRESS` to point at it, then start the fake-logind stub before gnome-shell.
- No new packages needed — GJS is already in the image.

See also: PR #74 (Option B — elogind) which takes the approach of installing elogind as a real logind provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)