### PR TITLE
fix(e2e): install elogind to provide logind in Docker

### DIFF
--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     xvfb \
     dbus-x11 \
     dbus \
+    elogind \
     at-spi2-core \
     libgl1-mesa-dri \
     libglx-mesa0 \

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -17,7 +17,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN useradd -ms /bin/bash tester && \
     mkdir -p /tmp/runtime-tester && \
     chown tester:tester /tmp/runtime-tester && \
-    chmod 700 /tmp/runtime-tester
+    chmod 700 /tmp/runtime-tester && \
+    mkdir -p /tmp/.X11-unix && \
+    chmod 1777 /tmp/.X11-unix
 
 COPY run-test.sh /run-test.sh
 RUN chmod +x /run-test.sh

--- a/test/e2e/run-test.sh
+++ b/test/e2e/run-test.sh
@@ -45,10 +45,12 @@ gsettings set org.gnome.shell enabled-extensions "['${UUID}']"
 
 if [ "${MODE}" = "x11" ]; then
     DISPLAY=:99 \
+    XDG_SESSION_TYPE=x11 \
     LIBGL_ALWAYS_SOFTWARE=1 \
     MUTTER_DISABLE_ANIMATIONS=1 \
         gnome-shell >"${LOG}" 2>&1 &
 else
+    XDG_SESSION_TYPE=wayland \
     MUTTER_DEBUG_DUMMY_MODE_SPECS="1920x1080" \
     MUTTER_DISABLE_ANIMATIONS=1 \
         gnome-shell --headless >"${LOG}" 2>&1 &

--- a/test/e2e/run-test.sh
+++ b/test/e2e/run-test.sh
@@ -43,6 +43,30 @@ MODE="$1"; UUID="$2"; LOG="$3"; SETTLE="$4"
 # Enable the extension before gnome-shell reads settings
 gsettings set org.gnome.shell enabled-extensions "['${UUID}']"
 
+# Start a system D-Bus daemon and elogind so gnome-shell can connect to
+# org.freedesktop.login1. Without a real logind, gnome-shell 46 throws
+# during background init and dies from a C-level heap abort.
+SYSTEM_BUS_SOCK=/tmp/system-dbus.sock
+dbus-daemon --config-file=/dev/stdin \
+    --address="unix:path=${SYSTEM_BUS_SOCK}" \
+    --print-pid --fork >/dev/null <<'DBUSCONF'
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <type>system</type>
+  <allow_anonymous/>
+  <policy context="default">
+    <allow send_destination="*" eavesdrop="true"/>
+    <allow eavesdrop="true"/>
+    <allow own="*"/>
+  </policy>
+</busconfig>
+DBUSCONF
+export DBUS_SYSTEM_BUS_ADDRESS="unix:path=${SYSTEM_BUS_SOCK}"
+/usr/lib/elogind/elogind &
+ELOGIND_PID=$!
+sleep 2
+
 if [ "${MODE}" = "x11" ]; then
     DISPLAY=:99 \
     XDG_SESSION_TYPE=x11 \
@@ -88,5 +112,6 @@ fi
 
 kill "${GS_PID}" 2>/dev/null || true
 wait "${GS_PID}" 2>/dev/null || true
+kill "${ELOGIND_PID}" 2>/dev/null || true
 echo "  PASS: ${MODE} test complete"
 INNER


### PR DESCRIPTION
## Problem

The E2E tests crash because gnome-shell 46 connects to `org.freedesktop.login1` on the **system D-Bus** during background initialisation (`loginManager.js:96`). In Docker containers without systemd/elogind running, this throws an uncaught JS exception that triggers a C-level heap abort:

```
(gnome-shell:26): Gjs-CRITICAL: JS ERROR: Gio.IOErrorEnum: Could not connect: No such file or directory
corrupted size vs. prev_size in fastbins
Aborted (core dumped)
```

## Fix (Option B — elogind)

- Add `elogind` to the Dockerfile apt packages — it's a drop-in logind implementation that works without systemd.
- In `run-test.sh`, start a permissive `dbus-daemon` on a local socket as the system bus (`DBUS_SYSTEM_BUS_ADDRESS`), then start elogind against it before gnome-shell.
- elogind registers a real `org.freedesktop.login1` service, satisfying gnome-shell's requirement.

See also: PR #73 (Option A — GJS stub) which avoids the extra package by registering a minimal fake logind service using GJS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)