### PR TITLE
prefs: expose shader-gamma as Dimming curve spin row

### DIFF
--- a/src/prefs.js
+++ b/src/prefs.js
@@ -137,6 +137,19 @@ const PreferencesPage = GObject.registerClass(class PreferencesPage extends Adw.
             this._settings.bind('min-brightness', this.min_brightness_control, 'value', Gio.SettingsBindFlags.DEFAULT);
             group.add(this.min_brightness_control);
 
+            this.shader_gamma_control = new Adw.SpinRow({
+                title: _('Dimming curve (1.0–4.0):'),
+                subtitle: this._getDescription('shader-gamma'),
+                digits: 1,
+                adjustment: new Gtk.Adjustment({
+                    lower: 1.0,
+                    upper: 4.0,
+                    step_increment: 0.1,
+                }),
+            });
+            this._settings.bind('shader-gamma', this.shader_gamma_control, 'value', Gio.SettingsBindFlags.DEFAULT);
+            group.add(this.shader_gamma_control);
+
             this.clone_mouse_control = new Adw.SwitchRow({
                 title: _('Mouse cursor brightness control:'),
                 subtitle: this._getDescription('clone-mouse'),


### PR DESCRIPTION
Adds a **Dimming curve (1.0–4.0)** SpinRow to the preferences UI, bound to the existing `shader-gamma` setting (already in the schema, default 2.0, not previously exposed in the UI).

## What this does

The dimming curve controls how brightness is applied:
- **1.0** — linear (multiply blend): `out = brightness × in`. Each colour channel scales uniformly. Best for OLED displays where multiply gives the most accurate result.
- **2.0** (default) — gamma-corrected: shadows are preserved better, highlights compress more aggressively.
- **4.0** — more aggressive shadow preservation.

OLED users who want true multiply-style dimming can set it to 1.0. The default stays at 2.0 which is the recommended starting point for most displays.

## Implementation

Single SpinRow, digits=1, step=0.1, bound via `Gio.SettingsBindFlags.DEFAULT`. Follows the same pattern as the existing min-brightness SpinRow.

Closes #29