### PR TITLE
test: compile schemas in E2E container after zip install

### DIFF
--- a/test/e2e/run-test.sh
+++ b/test/e2e/run-test.sh
@@ -16,6 +16,10 @@ mkdir -p "${EXT_DIR}"
 unzip -q /ext.zip -d "${EXT_DIR}"
 echo "  installed ${UUID}"
 
+# Compile schemas — the zip ships only the .xml (e.g.o. requirement);
+# we must compile locally before GNOME Shell tries to load them.
+glib-compile-schemas "${EXT_DIR}/schemas/"
+
 # Start Xvfb for X11 mode before the dbus session
 XVFB_PID=""
 if [ "${MODE}" = "x11" ]; then


### PR DESCRIPTION
## What

Adds `glib-compile-schemas` call in `run-test.sh` after the extension zip is extracted.

## Why

`b85c6ebb` correctly removed `gschemas.compiled` from the extension zip (extensions.gnome.org flags pre-compiled binary artifacts and compiles schemas itself). But the E2E test installs the zip directly without going through the GNOME extension manager, so it never gets schemas compiled — causing GNOME Shell to fail with:

```
GLib.FileError: Failed to open file ".../schemas/gschemas.compiled": open() failed: No such file or directory
```

Both the Ubuntu 24.04 and Fedora 43 containers have `glib-compile-schemas` available via `gnome-shell`'s dependency on `libglib2.0-bin` / `glib2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)