### PR TITLE
fix: replace xorg-x11-utils with xwininfo for Fedora 43

### DIFF
--- a/test/e2e/Dockerfile.gnome49
+++ b/test/e2e/Dockerfile.gnome49
@@ -14,7 +14,7 @@ RUN dnf -y copr enable frantisekz/GNOME-X11 && dnf -y update && \
         mesa-libGL \
         unzip \
         ImageMagick \
-        xorg-x11-utils \
+        xwininfo \
         && \
     dnf clean all
 


### PR DESCRIPTION
## Problem

The `E2E GNOME 49 (Fedora 43)` CI job is failing because `xorg-x11-utils` was removed from the Fedora 43 package repos. The Docker image build errors out with:

```
No match for argument: xorg-x11-utils
```

## Fix

The only tool from `xorg-x11-utils` that the E2E test script actually uses is `xwininfo` (in `run-test.sh`, to count windows on the Xvfb display). `xwininfo` is now its own standalone package in Fedora 43.

Replace `xorg-x11-utils` → `xwininfo` in `Dockerfile.gnome49`.